### PR TITLE
Enable "import/no-anonymous-default-exports" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,9 +2,7 @@ module.exports = {
   extends: [
     "airbnb-base",
     // Only this is needed to integrate Prettier, see: https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
-    "plugin:prettier/recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:prettier/recommended"
   ],
   rules: {
     "linebreak-style": ["error", (process.platform === "win32" ? "windows" : "unix")], // https://stackoverflow.com/q/39114446/2771889

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,8 @@ module.exports = {
     "airbnb-base",
     // Only this is needed to integrate Prettier, see: https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
     "plugin:prettier/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
   ],
   rules: {
     "linebreak-style": ["error", (process.platform === "win32" ? "windows" : "unix")], // https://stackoverflow.com/q/39114446/2771889
@@ -23,5 +25,6 @@ module.exports = {
         message: "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
       },
     ],
+    "import/no-anonymous-default-export": "error"
   },
 };


### PR DESCRIPTION
According to https://github.com/benmosher/eslint-plugin-import#installation:

> All rules are off by default.

As it was pointed out (https://github.com/c-hive/guides/pull/42), "unnamed default export" isn't considered to be a good practice (because of the lacking debugging info). Let's forbid them by enabling the corresponding rule.